### PR TITLE
Crosscode 0.7 dev pre_fill and determinism fixes

### DIFF
--- a/worlds/crosscode/options.py
+++ b/worlds/crosscode/options.py
@@ -242,10 +242,10 @@ class Reachability(Choice):
         """
         if self.value == Reachability.option_own_world:
             for _, lst in self.items.items():
-                local_items |= lst
+                local_items.update(lst)
         elif self.value == Reachability.option_different_world:
             for _, lst in self.items.items():
-                non_local_items |= lst
+                non_local_items.update(lst)
 
 class DungeonReachability(Reachability):
     """
@@ -265,7 +265,7 @@ class DungeonReachability(Reachability):
         """
         if self.value == DungeonReachability.option_own_dungeons:
             for _, lst in self.items.items():
-                all_dungeons |= lst
+                all_dungeons.update(lst)
         if self.value == DungeonReachability.option_original_dungeons:
             for key, lst in self.items.items():
                 specific_dungeons[key] |= lst

--- a/worlds/crosscode/world.py
+++ b/worlds/crosscode/world.py
@@ -666,6 +666,19 @@ class CrossCodeWorld(World):
         # Remove dungeon items we are about to put in from the state so that we don't double count
         for item in all_items_list:
             all_state.remove(item)
+
+        # Prevent minimal accessibility from locking non-required keys, and other dungeon items, behind themselves when
+        # the goal is reachable without them.
+        if self.options.accessibility == "minimal":
+            if all_state.has("Victory", self.player):
+                # Remove the event that the completion_condition checks for, so that the completion condition will
+                # return False.
+                all_state.remove_item("Victory", self.player)
+            else:
+                # Tell the all_state that it has already collected the item from the location the "Victory" event is
+                # placed at, so that it won't collect the "Victory" event when sweeping.
+                all_state.advancements.add(self.get_location("The Creator"))
+
         all_state.sweep_for_advancements()
 
         cclogger.debug("master_key_shuffle: %s", self.options.master_key_shuffle)

--- a/worlds/crosscode/world.py
+++ b/worlds/crosscode/world.py
@@ -588,6 +588,12 @@ class CrossCodeWorld(World):
                 if loc.data.access.cond is not None:
                     add_rule(loc, condition_satisfied(self.player, loc.data.access.cond, loc.data.code, self.logic_dict))
 
+    def get_pre_fill_items(self) -> list[Item]:
+        pre_fill_items = self.pre_fill_any_dungeon.copy()
+        for dungeon in self.dungeon_areas:
+            pre_fill_items.extend(self.pre_fill_specific_dungeons[dungeon])
+        return pre_fill_items
+
     def pre_fill(self):
         allowed_locations_by_item: dict[Item, set[CrossCodeLocation]] = {}
         all_items_list = list(self.pre_fill_any_dungeon)

--- a/worlds/crosscode/world.py
+++ b/worlds/crosscode/world.py
@@ -307,7 +307,8 @@ class CrossCodeWorld(World):
         self.required_items = Counter()
         self.required_items.update(self.pools.item_pools["required"])
 
-        for name in self._equip_chain_names:
+        # self._equip_chain_names is a set, so sort for deterministic results.
+        for name in sorted(self._equip_chain_names):
             self.required_items.update(self.pools.item_pools[f"pool:{name}"])
 
         if self.options.shop_rando.value:
@@ -522,7 +523,8 @@ class CrossCodeWorld(World):
         replaced: dict[str, list[CrossCodeItem]] = defaultdict(list)
 
         # deal with progressive chains
-        for chain_name in self.enabled_chain_names:
+        # self.enabled_chain_names is a set, so sort for deterministic results.
+        for chain_name in sorted(self.enabled_chain_names):
             chain = self.pools.progressive_chains[chain_name]
             # item_to_add is the "Progressive [X]" item
             item_to_add = self.world_data.progressive_items[chain_name]
@@ -590,7 +592,10 @@ class CrossCodeWorld(World):
 
     def get_pre_fill_items(self) -> list[Item]:
         pre_fill_items = self.pre_fill_any_dungeon.copy()
-        for dungeon in self.dungeon_areas:
+        # self.dungeon_areas is a set, so sort for deterministic results. This probably isn't necessary in most cases,
+        # but other apworlds could do whatever they like with the returned list, so it is safer to return a list with a
+        # deterministic order.
+        for dungeon in sorted(self.dungeon_areas):
             pre_fill_items.extend(self.pre_fill_specific_dungeons[dungeon])
         return pre_fill_items
 
@@ -628,7 +633,8 @@ class CrossCodeWorld(World):
         for item in self.pre_fill_any_dungeon:
             allowed_locations_by_item[item] = all_locations
 
-        all_locations_list = list(all_locations)
+        # all_locations is a set, so sort for deterministic results.
+        all_locations_list = sorted(all_locations)
         self.random.shuffle(all_locations_list)
 
         # Get the list of items and sort by priority

--- a/worlds/crosscode/world.py
+++ b/worlds/crosscode/world.py
@@ -649,10 +649,11 @@ class CrossCodeWorld(World):
         all_items_list.sort(key=priority, reverse=True)
 
         # Set up state
-        all_state = self.multiworld.get_all_state(use_cache=False)
+        all_state = self.multiworld.get_all_state(use_cache=False, perform_sweep=False)
         # Remove dungeon items we are about to put in from the state so that we don't double count
         for item in all_items_list:
             all_state.remove(item)
+        all_state.sweep_for_advancements()
 
         cclogger.debug("master_key_shuffle: %s", self.options.master_key_shuffle)
         cclogger.debug("small_key_shuffle: %s", self.options.small_key_shuffle)

--- a/worlds/crosscode/world.py
+++ b/worlds/crosscode/world.py
@@ -634,20 +634,21 @@ class CrossCodeWorld(World):
         # Get the list of items and sort by priority
         def priority(item: CrossCodeItem) -> int:
             # 0 - Master dungeon-specific
-            # 1 - Element dungeon-specific
-            # 2 - Key dungeon-specific
+            # 1 - Key dungeon-specific
+            # 2 - Element dungeon-specific
             # 3 - Other dungeon-specific
             # 4 - Master any local dungeon
-            # 5 - Element any local dungeon
-            # 6 - Key any local dungeon
+            # 5 - Key any local dungeon
+            # 6 - Element any local dungeon
             # 7 - Other any local dungeon
-            i = 3
-            if item.name in ("Heat", "Cold", "Shock", "Wave"):
-                i = 0
             if "Master" in item.name:
-                i = 1
+                i = 0
             elif "Key" in item.name:
+                i = 1
+            elif item.name in ("Heat", "Cold", "Shock", "Wave"):
                 i = 2
+            else:
+                i = 3
             if allowed_locations_by_item[item] is all_locations:
                 i += 4
             return i

--- a/worlds/crosscode/world.py
+++ b/worlds/crosscode/world.py
@@ -281,7 +281,6 @@ class CrossCodeWorld(World):
 
         self.variables = defaultdict(list)
 
-        start_inventory = self.options.start_inventory.value
         # self.logic_mode = self.options.logic_mode.current_key
         self.logic_mode = "open"
         self.region_pack = self.world_data.region_packs[self.logic_mode]
@@ -332,16 +331,16 @@ class CrossCodeWorld(World):
             self.multiworld.push_precollected(self.create_item(green_leaf_shade_name))
 
         if self.options.start_with_chest_detector.value:
-            start_inventory["Chest Detector"] = 1
+            self.multiworld.push_precollected(self.create_item("Chest Detector"))
 
         if self.options.start_with_discs.value & StartWithDiscs.option_insight:
-            start_inventory["Disc of Insight"] = 1
+            self.multiworld.push_precollected(self.create_item("Disc of Insight"))
         if self.options.start_with_discs.value & StartWithDiscs.option_flora:
-            start_inventory["Disc of Flora"] = 1
+            self.multiworld.push_precollected(self.create_item("Disc of Flora"))
 
         if self.options.start_with_pet.value:
             chosen_pet = self.pools.pull_items_from_pool("pets", self.random)[0]
-            start_inventory[chosen_pet.name] = 1
+            self.multiworld.push_precollected(self.create_item(chosen_pet.name))
 
         if self.options.chest_lock_randomization.value:
             self._chest_lock_weights = list(itertools.accumulate([

--- a/worlds/crosscode/world.py
+++ b/worlds/crosscode/world.py
@@ -645,7 +645,8 @@ class CrossCodeWorld(World):
             if allowed_locations_by_item[item] is all_locations:
                 i += 4
             return i
-        all_items_list.sort(key=priority)
+        # Items are placed starting from the end of the list.
+        all_items_list.sort(key=priority, reverse=True)
 
         # Set up state
         all_state = self.multiworld.get_all_state(use_cache=False)


### PR DESCRIPTION
This fixes some dungeon pre_fill and deterministic generation issues.

Each commit has a separate explanation in the commit message, below is a summary.

- Items passed to fill_restrictive are placed starting from the end of the list, but the original code seemed to be sorting the items to place in the reverse order of what was intended
- all_state was sweeping to pick up placed items *before* dungeon items were removed from its inventory, resulting in an invalid state that could have picked up pre-placed items that were only reachable because of the dungeon items that were not removed before sweeping
- get_pre_fill_items was not implemented (there is a `test.general.test_implemented.TestImplemented.test_prefill_items` core AP unit test that tests for this, but core AP unit tests only run on default settings), so, before this, the dungeon items to remove were never even collected into the all_state to begin with
- place all dungeon keys before elements, this seems to fully fix the rare FillErrors in pre_fill, though it's possible there could still be very rare fill failures
- fix nondeterministic iteration of sets, sets are unordered and typically have a different order for each python process, so care needs to be taken when it is necessary to iterate their contents

Included are three changes that are not technically fixes, but are suggestions to avoid potential issues, or improve existing behaviour:
- Remove "Victory" from pre_fill all_state to prevent locked dungeons
- Replace modifying the start_inventory option directly
- Replace unsafe in-place set unions