### PR TITLE
Raise OptionError if both consumable_weight and drop_weight are zero

### DIFF
--- a/worlds/crosscode/world.py
+++ b/worlds/crosscode/world.py
@@ -255,6 +255,9 @@ class CrossCodeWorld(World):
         cons = self.options.consumable_weight.value
         drop = self.options.drop_weight.value
 
+        if not drop and not cons:
+            raise OptionError("One of either consumable_weight or drop_weight must be non-zero.")
+
         # cumulative weights save work.
         self._filler_pool_weights = list(itertools.accumulate([
             common * cons,


### PR DESCRIPTION
## What is this fixing or adding?
This raises an `OptionError` specifically if both `consumable_weight` and `drop_weight` are zero, rather than a `ValueError` from `random`

## How was this tested?
I genned with a yaml that has both options set to zero, it failed with an `OptionError` and the specific message

## If this makes graphical changes, please attach screenshots.
N/A