### PR TITLE
add botanics completion amount support

### DIFF
--- a/worlds/crosscode/options.py
+++ b/worlds/crosscode/options.py
@@ -93,6 +93,21 @@ class QuestRando(Toggle):
     """
     display_name = "Quest Randomization"
 
+class BotanicsAmount(Range):
+    """
+    The number of plants required to turn in the quest "Crocus Pocus".
+    """
+    display_name = "Botanics Completion Amount"
+
+    range_start = 1
+    range_end = 88
+    default = 77
+
+    special_range_names = {
+        "vanilla": 77,
+        "dlc": 88,
+    }
+
 class HiddenQuestRewardMode(Choice):
     """
     Some quests hide their rewards until they are completed.
@@ -526,6 +541,7 @@ class CrossCodeOptions(PerGameCommonOptions):
     vt_skip: VTSkip
 
     quest_rando: QuestRando
+    botanics_completion_amount: BotanicsAmount
     hidden_quest_reward_mode: HiddenQuestRewardMode
     hidden_quest_obfuscation_level: HiddenQuestObfuscationLevel
     quest_dialog_hints: QuestDialogHints
@@ -576,6 +592,7 @@ option_groups: list[OptionGroup] = [
         name="Quests",
         options=[
             QuestRando,
+            BotanicsAmount,
             HiddenQuestRewardMode,
             HiddenQuestObfuscationLevel,
             QuestDialogHints,
@@ -588,6 +605,12 @@ option_groups: list[OptionGroup] = [
             ShopDialogHints,
             ShopSendMode,
             ShopReceiveMode
+        ]
+    ),
+    OptionGroup(
+        name="Botanics",
+        options=[
+            Botanity,
         ]
     ),
     OptionGroup(

--- a/worlds/crosscode/types/slot.py
+++ b/worlds/crosscode/types/slot.py
@@ -19,6 +19,7 @@ class SlotOptions(typing.TypedDict):
     shopReceiveMode: str
     shopDialogHints: bool
     chestClearanceLevels: dict[int, str]
+    botanicsCompletionAmount: int
 
 class SlotData(typing.TypedDict):
     mode: str

--- a/worlds/crosscode/world.py
+++ b/worlds/crosscode/world.py
@@ -789,6 +789,7 @@ class CrossCodeWorld(World):
                 "shopReceiveMode": shop_receive_mode_string,
                 "shopDialogHints": bool(self.options.shop_dialog_hints.value),
                 "chestClearanceLevels": self.logic_dict["chest_clearance_levels"],
+                "botanicsCompletionAmount": self.options.botanics_completion_amount.value,
             }
         }
 


### PR DESCRIPTION
This PR adds an option to change the number of plants required for Crocus Pocus.