### PR TITLE
add version to slotdata for sanity checking

### DIFF
--- a/worlds/crosscode/common.py
+++ b/worlds/crosscode/common.py
@@ -8,4 +8,5 @@ from Utils import Version
 NAME: str = "CrossCode"
 BASE_ID: int = 3235824000
 DATA_VERSION: str = "0.5"
+APWORLD_VERSION_STRING = "0.8.2-pre.1"
 APWORLD_VERSION: Version = Version(0, 8, 2)

--- a/worlds/crosscode/templates/common.template.py
+++ b/worlds/crosscode/templates/common.template.py
@@ -5,4 +5,5 @@ from Utils import Version
 NAME: str = "CrossCode"
 BASE_ID: int = {{base_id}}
 DATA_VERSION: str = "{{data_version}}"
+APWORLD_VERSION_STRING = "{{version[0]}}.{{version[1]}}.{{version[2]}}{% if version | length > 3 %}-{{version[3]}}{% endif %}"
 APWORLD_VERSION: Version = Version({{version[0]}}, {{version[1]}}, {{version[2]}})

--- a/worlds/crosscode/types/slot.py
+++ b/worlds/crosscode/types/slot.py
@@ -21,4 +21,5 @@ class SlotOptions(typing.TypedDict):
 class SlotData(typing.TypedDict):
     mode: str
     dataVersion: str
+    apworldVersion: str
     options: SlotOptions

--- a/worlds/crosscode/world.py
+++ b/worlds/crosscode/world.py
@@ -14,7 +14,7 @@ from Options import OptionError
 from worlds.AutoWorld import WebWorld, World
 from worlds.generic.Rules import add_rule
 
-from .common import NAME
+from .common import NAME, APWORLD_VERSION_STRING
 from .logic import condition_satisfied
 from .world_data import static_world_data
 
@@ -754,6 +754,7 @@ class CrossCodeWorld(World):
         return {
             "mode": self.logic_mode,
             "dataVersion": self.world_data.data_version,
+            "apworldVersion": APWORLD_VERSION_STRING,
             "options": {
                 "goal": self.options.goal.current_key,
                 "vtShadeLock": self.options.vt_shade_lock.value,


### PR DESCRIPTION
Add full version as string to `common.py` and slot data.

This is to support the following CCMWR PR: https://github.com/CodeTriangle/CCMultiworldRandomizer/pull/52