### PR TITLE
Tweak bundle script to output archipelago.json

### DIFF
--- a/worlds/crosscode/archipelago.json
+++ b/worlds/crosscode/archipelago.json
@@ -1,0 +1,1 @@
+{"compatible_version": 7, "version": 7, "game": "CrossCode", "world_version": "0.9.0"}

--- a/worlds/crosscode/bundle.py
+++ b/worlds/crosscode/bundle.py
@@ -13,6 +13,15 @@ FILE_EXCLUDES = (
     "bundle",
 )
 
+with open("worlds/crosscode/archipelago.json", "wb") as f:
+    print(f"Generating manifest")
+
+    container = APWorldContainer()
+    container.game = NAME
+    container.world_version = APWORLD_VERSION
+
+    f.write(json.dumps(container.get_manifest()).encode())
+
 def bundle():
     zipfile = ZipFile(f"crosscode.apworld", "w", compression=ZIP_DEFLATED, compresslevel=9)
     for root, _, files in os.walk("worlds/crosscode"):
@@ -23,14 +32,6 @@ def bundle():
                     internal_name = f"{root[7:]}/{filename}"
                     print(f"Compressing {fullname} to {internal_name}")
                     zipfile.write(fullname, internal_name)
-    with zipfile.open(f"archipelago.json", "w") as f:
-        print(f"Generating manifest")
-
-        container = APWorldContainer()
-        container.game = NAME
-        container.world_version = APWORLD_VERSION
-
-        f.write(json.dumps(container.get_manifest()).encode())
 
     zipfile.close()
 


### PR DESCRIPTION
This PR makes the bundle script srite archipelago.json to the filesystem itself instead of only to the `.apworld` archive to support apworld versions in source-only installations.
