### PR TITLE
Adding a chest reveal YAML option

### DIFF
--- a/worlds/crosscode/options.py
+++ b/worlds/crosscode/options.py
@@ -262,6 +262,13 @@ class AllowBoosterGrinding(Toggle):
     """
     display_name = "Allow Booster Grinding"
 
+class ChestReveal(Toggle):
+    """
+    If enabled, shows the category of all chests without having to reach the room chests are in first.
+    If disabled, the player must reach the room with chests to know what category the chests are.
+    """
+    display_name = "Chest Reveal"
+
 class RhombusHubUnlock(Toggle):
     """
     If enabled, allows traveling to areas out of order from the hub in Rhombus Square. Allows skipping areas such as
@@ -576,6 +583,7 @@ class CrossCodeOptions(PerGameCommonOptions):
     progressive_equipment: ProgressiveEquipment
     keyrings: Keyrings
     allow_booster_grinding: AllowBoosterGrinding
+    chest_reveal: ChestReveal
 
     shade_shuffle: ShadeShuffle
     element_shuffle: ElementShuffle

--- a/worlds/crosscode/types/slot.py
+++ b/worlds/crosscode/types/slot.py
@@ -9,6 +9,7 @@ class SlotOptions(typing.TypedDict):
     closedGaia: int
     vtSkip: bool
     keyrings: list[int]
+    chestReveal: bool
     allowBoosterGrinding: bool
     questRando: bool
     hiddenQuestRewardMode: str

--- a/worlds/crosscode/world.py
+++ b/worlds/crosscode/world.py
@@ -794,6 +794,7 @@ class CrossCodeWorld(World):
                 "closedGaia": self.options.closed_gaia.value,
                 "vtSkip": bool(self.options.vt_skip.value),
                 "keyrings": [self.world_data.single_items_dict[name].item_id for name in self.logic_dict["keyrings"]],
+                "chestReveal": bool(self.options.chest_reveal.value),
                 "allowBoosterGrinding": bool(self.options.allow_booster_grinding),
                 "questRando": bool(self.options.quest_rando.value),
                 "hiddenQuestRewardMode": self.options.hidden_quest_reward_mode.current_key,


### PR DESCRIPTION
## What is this fixing or adding?
Putting in an YAML option to show the categories of chests without having to reach the room first. Allowing faster runs for use in shorter length syncs.


## How was this tested?
Tested with local-made build of changes with the setting turned on and off, both working as expected.

